### PR TITLE
A POST on a collection must match with a create function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Your Controllers should feature at least the following functions, which should e
 
 Returns an Array of instances of the matching Model for this Controller.
 
+#####POST (API Root)/collection maps to `create()`
+
+Create a single instance of the matching Model for this Controller.
+
 #####GET (API Root)/collection/{id} maps to `fetch()`
 
 Returns a single instance of the matching Model for this Controller.

--- a/src/utils/RAML.js
+++ b/src/utils/RAML.js
@@ -181,12 +181,18 @@ export default class RAML {
                     switch(method.method) {
                         case 'patch':
                         case 'post':
+                            if (method.method === 'post') {
+                                //Catch POST methods only
+                                if (methodClassFunction === 'list') {
+                                    debug(`Special case, this is a POST on collection, which is a create()`);
+                                    methodClassFunction = 'create';
+                                }
+                            }
+
+                            //POST or PATCH
                             if (methodClassFunction === 'fetch') {
                                 debug(`Special case, this is a POST or PATCH at {id}, which is an update()`);
                                 methodClassFunction = 'update';
-                            } else if (methodClassFunction === 'list' && method.method === 'post') {
-                              debug(`Special case, this is a POST on collection, which is a create()`);
-                              methodClassFunction = 'create';
                             }
                             break;
                         case 'delete':

--- a/src/utils/RAML.js
+++ b/src/utils/RAML.js
@@ -184,6 +184,9 @@ export default class RAML {
                             if (methodClassFunction === 'fetch') {
                                 debug(`Special case, this is a POST or PATCH at {id}, which is an update()`);
                                 methodClassFunction = 'update';
+                            } else if (methodClassFunction === 'list' && method.method === 'post') {
+                              debug(`Special case, this is a POST on collection, which is a create()`);
+                              methodClassFunction = 'create';
                             }
                             break;
                         case 'delete':

--- a/test/utils/RAML.test.js
+++ b/test/utils/RAML.test.js
@@ -356,6 +356,34 @@ describe('RAML', () => {
             });
         });
 
+        it('should convert URIs of `collection` resources with no subpath in the URI an a method of `post` to be `create()` commands', () => {
+          let expectedClassFunction = 'create';
+          let resources = [
+            {
+              relativeUri: '/objects',
+              type: 'collection',
+              methods: [{
+                method: 'post'
+              }]
+            }];
+
+          sinon.stub(mockParser, 'loadFile', () => {
+            return new Promise((resolve) => {
+              resolve({
+                baseUri: 'http://',
+                resources: resources
+              });
+            });
+          });
+
+          return newRAML.getRouteMap()
+            .then((mappedRoutes) => {
+              let mappedRoute = mappedRoutes[0];
+
+              return expect(mappedRoute.classFunction).to.equal(expectedClassFunction);
+            });
+        });
+
         it('should convert URIs of `collection` resources with a subpath in the URI to be commands matching the subpath', () => {
             let expectedClassFunction = 'create';
             let resources = [

--- a/test/utils/RAML.test.js
+++ b/test/utils/RAML.test.js
@@ -357,30 +357,30 @@ describe('RAML', () => {
         });
 
         it('should convert URIs of `collection` resources with no subpath in the URI an a method of `post` to be `create()` commands', () => {
-          let expectedClassFunction = 'create';
-          let resources = [
-            {
-              relativeUri: '/objects',
-              type: 'collection',
-              methods: [{
-                method: 'post'
-              }]
-            }];
+            let expectedClassFunction = 'create';
+            let resources = [
+                {
+                    relativeUri: '/objects',
+                    type: 'collection',
+                    methods: [{
+                        method: 'post'
+                    }]
+                }];
 
-          sinon.stub(mockParser, 'loadFile', () => {
-            return new Promise((resolve) => {
-              resolve({
-                baseUri: 'http://',
-                resources: resources
-              });
+            sinon.stub(mockParser, 'loadFile', () => {
+                return new Promise((resolve) => {
+                    resolve({
+                        baseUri: 'http://',
+                        resources: resources
+                    });
+                });
             });
-          });
 
-          return newRAML.getRouteMap()
+            return newRAML.getRouteMap()
             .then((mappedRoutes) => {
-              let mappedRoute = mappedRoutes[0];
+                let mappedRoute = mappedRoutes[0];
 
-              return expect(mappedRoute.classFunction).to.equal(expectedClassFunction);
+                return expect(mappedRoute.classFunction).to.equal(expectedClassFunction);
             });
         });
 


### PR DESCRIPTION
To create a resource, the standard is to POST on the collection URI.